### PR TITLE
feat: Warn if fields are not annotated as strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
         run: poetry run lint-imports
       - name: Check if requirements.txt is up-to-date
         run: poetry export --with=dev --output docker/requirements.txt && git diff --exit-code
+      - name: Run tests that does not need the Glue container
+        run: poetry run pytest test/test_options.py
       - name: Build python packages
         run: poetry build
   tests:
@@ -57,7 +59,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build container and run tests
-        run: USER_ID=$(id -u) TARGET=coverage docker compose --file docker/docker-compose.yml run --rm --build glue-utils -c "pytest --cov-report=html --cov-report=xml"
+        run: USER_ID=$(id -u) TARGET=coverage docker compose --file docker/docker-compose.yml run --rm --build glue-utils -c "pytest --cov=glue_utils --cov-report=term --cov-report=xml"
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test: docker/requirements.txt ## Run automated tests
 
 .PHONY: coverage
 coverage: docker/requirements.txt ## Run tests and measure code coverage
-	@TARGET=coverage $(DOCKER_COMPOSE_RUN) -c "pytest --cov-report=html --cov-report=xml"
+	@TARGET=coverage $(DOCKER_COMPOSE_RUN) -c "pytest --cov=glue_utils --cov-report=term --cov-report=html"
 
 
 .PHONY: shell

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,15 +3,16 @@ FROM amazon/aws-glue-libs:glue_libs_4.0.0_image_01 as base
 
 # Copy requirements file that contains tooling.
 WORKDIR /home/glue_user/workspace
-COPY docker/requirements.txt ./
 
-RUN pip3 install --no-cache-dir --no-warn-script-location --user --upgrade pip==24.0 \
-  # Install dev requirements.
-  && pip3 install --no-cache-dir --no-warn-script-location --user -r requirements.txt
+RUN pip3 install --no-cache-dir --no-warn-script-location --user --upgrade pip==24.0
 
 
 # ----------------------- Test -----------------------
 FROM base as test
+
+COPY docker/requirements.txt ./
+
+RUN pip3 install --no-cache-dir --no-warn-script-location --user -r requirements.txt
 
 COPY src pyproject.toml README.md ./
 
@@ -37,6 +38,10 @@ RUN usermod -u "$USER_ID" glue_user \
 
 # Switch to glue_user to be able to make changes for the user itself.
 USER glue_user
+
+COPY docker/requirements.txt ./
+
+RUN pip3 install --no-cache-dir --no-warn-script-location --user -r requirements.txt
 
 COPY src pyproject.toml README.md ./
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,9 @@ ignore = [
     # line-too-long
     "E501",
     # Ignore camelCase attributes since Glue uses a lot of them
-    "N815"
+    "N815",
+    # X | Y syntax does not play well with get_type_hints in Python 3.9
+    "UP007"
 ]
 # # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
@@ -106,9 +108,10 @@ disallow_incomplete_defs = false
 disallow_untyped_defs = false
 
 [tool.pytest.ini_options]
-addopts = "-p no:cacheprovider --cov=glue_utils --cov-report=term"
+addopts = "-p no:cacheprovider"
 filterwarnings = [
     "ignore::FutureWarning:pyspark.sql.context",
+    "ignore::UserWarning:test.test_options",
 ]
 
 [tool.coverage.run]

--- a/src/glue_utils/options.py
+++ b/src/glue_utils/options.py
@@ -4,15 +4,32 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass, fields
-from typing import Any
+from typing import Any, get_type_hints
+from warnings import warn
 
 from awsglue.utils import getResolvedOptions
 from typing_extensions import Self
 
 
+class UnsupportedTypeWarning(UserWarning):
+    """Warning for unsupported field types."""
+
+
 @dataclass
 class BaseOptions:
     """Dataclass for storing resolved options."""
+
+    @classmethod
+    def __init_subclass__(cls) -> None:
+        """Warn if fields are not strings."""
+        for name, type_hint in get_type_hints(cls).items():
+            if type_hint is not str:
+                warn(
+                    f'"{name}" value is a string at runtime even if annotated to be "{type_hint}".',
+                    UnsupportedTypeWarning,
+                    stacklevel=2,
+                )
+        super().__init_subclass__()
 
     @classmethod
     def from_sys_argv(cls) -> Self:

--- a/src/glue_utils/pyspark/format_options.py
+++ b/src/glue_utils/pyspark/format_options.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, TypedDict
+from typing import Literal, TypedDict, Union
 
 
 class S3FormatOptions(TypedDict, total=False):
@@ -24,7 +24,7 @@ class CSVFormatOptions(S3FormatOptions, total=False):
 
     separator: str
     escaper: str
-    quoteChar: str | Literal[-1]
+    quoteChar: Union[str, Literal[-1]]
     multiLine: bool
     withHeader: bool
     writeHeader: bool

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, fields
+from typing import Optional, Union
 from unittest.mock import patch
 
 import pytest
 from glue_utils import BaseOptions
+from glue_utils.options import UnsupportedTypeWarning
 
 
 @pytest.fixture
@@ -69,7 +71,7 @@ class TestOptions:
 @dataclass
 class NullableOptions(BaseOptions):
     connection_name: str
-    source_database: str | None = None
+    source_database: Optional[str] = None
 
 
 class TestNullableOptions:
@@ -101,7 +103,7 @@ class TestNullableOptions:
 @dataclass
 class NullableOptionsWithDefaults(BaseOptions):
     connection_name: str = "my connection"
-    source_database: str | None = "my source"
+    source_database: Optional[str] = "my source"
 
 
 class TestNullableOptionsWithDefaults:
@@ -128,3 +130,52 @@ class TestNullableOptionsWithDefaults:
         assert options.connection_name == "my connection"
         assert options.source_database == "my source"
         assert len(fields(options)) == 2
+
+
+class TestOptionsWithNonString:
+    def test_warning_for_non_string_fields(self, mock_get_resolved_options):
+        mock_get_resolved_options.return_value = {
+            "JOB_NAME": "test-job",
+            "start_timestamp": "1632960000",
+            "end_timestamp": "1632963600",
+            "pi": "3.14159",
+        }
+
+        with pytest.warns(UnsupportedTypeWarning) as warnings:
+
+            @dataclass
+            class OptionsWithNonStrings(BaseOptions):
+                start_timestamp: int
+                end_timestamp: int
+                pi: Union[str, int, float]
+                mode: str = "incremental"
+
+            options = OptionsWithNonStrings.from_sys_argv()
+
+        assert isinstance(options.start_timestamp, str)
+        assert options.start_timestamp == "1632960000"
+
+        assert isinstance(options.end_timestamp, str)
+        assert options.end_timestamp == "1632963600"
+
+        assert isinstance(options.pi, str)
+        assert options.pi == "3.14159"
+
+        assert isinstance(options.mode, str)
+        assert options.mode == "incremental"
+
+        assert len(fields(options)) == 4
+
+        assert len(warnings) == 3
+        assert (
+            str(warnings[0].message)
+            == '"start_timestamp" value is a string at runtime even if annotated to be "<class \'int\'>".'
+        )
+        assert (
+            str(warnings[1].message)
+            == '"end_timestamp" value is a string at runtime even if annotated to be "<class \'int\'>".'
+        )
+        assert (
+            str(warnings[2].message)
+            == '"pi" value is a string at runtime even if annotated to be "typing.Union[str, int, float]".'
+        )


### PR DESCRIPTION
Fixes #63 .

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new feature that warns users if fields in dataclasses are not annotated as strings. It also includes a new test case to ensure that the warning mechanism works as expected.

* **New Features**:
    - Added a warning mechanism to notify if fields in dataclasses are not annotated as strings.
* **Tests**:
    - Introduced a new test case to verify that warnings are issued when fields are not annotated as strings.

<!-- Generated by sourcery-ai[bot]: end summary -->