### PR TITLE
refactor: Use an enum for log levels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,11 @@ test: docker/requirements.txt ## Run automated tests
 	@TARGET=test $(DOCKER_COMPOSE_RUN) -c pytest
 
 
+.PHONY: test-verbose
+test-verbose: docker/requirements.txt ## Run automated tests in verbose mode
+	@TARGET=test $(DOCKER_COMPOSE_RUN) -c "pytest -vv"
+
+
 .PHONY: coverage
 coverage: docker/requirements.txt ## Run tests and measure code coverage
 	@TARGET=coverage $(DOCKER_COMPOSE_RUN) -c "pytest --cov=glue_utils --cov-report=term --cov-report=html"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   glue-utils:
     image: glue-utils:latest


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request refactors the log level handling in the GluePySparkJob class by introducing a LogLevel enum. This change improves type safety and code readability. Additionally, a new test case has been added to ensure the correct initialization of log levels using the new enum.

- **Enhancements**:
    - Refactored the log level handling in GluePySparkJob to use an Enum class for better type safety and readability.
- **Tests**:
    - Added a new test case to verify the initialization of GluePySparkJob with different log levels using the new LogLevel enum.

<!-- Generated by sourcery-ai[bot]: end summary -->