### PR TITLE
ci: Use trivy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.7
+        with:
+          fetch-depth: 0
       - name: Diffset
         id: diffset
         uses: softprops/diffset@v2.0.1
@@ -82,15 +84,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-  pip-audit:
-    name: Audit requirements
+  trivy:
+    name: Trivy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.7
-      - name: Audit requirements using pip-audit
-        uses: pypa/gh-action-pip-audit@v1.0.8
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.24.0
         with:
-          inputs: docker/requirements.txt
+          scan-type: 'fs'
+          format: 'sarif'
+          output: 'trivy.sarif'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy.sarif'
 
   dockerfile:
     name: Check Dockerfile
@@ -125,12 +133,12 @@ jobs:
           directory: .
           quiet: true
           output_format: cli,sarif
-          output_file_path: console,results.sarif
+          output_file_path: console,checkov.sarif
       - name: Upload SARIF results
         if: success() || failure()
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: results.sarif
+          sarif_file: checkov.sarif
 
   gitleaks:
     name: Run Gitleaks

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,6 @@
 # ----------------------- Base -----------------------
 FROM amazon/aws-glue-libs:glue_libs_4.0.0_image_01 as base
 
-# Copy requirements file that contains tooling.
 WORKDIR /home/glue_user/workspace
 
 # hadolint ignore=DL3013


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the CI workflow by replacing the 'pip-audit' job with a 'trivy' job for vulnerability scanning. It also configures Trivy to output results in SARIF format and upload them to the GitHub Security tab. Additionally, the 'checkout' action is updated to fetch the full history.

- **CI**:
    - Replaced the 'pip-audit' job with a 'trivy' job to run the Trivy vulnerability scanner.
    - Configured Trivy to scan the filesystem, output results in SARIF format, and upload the results to the GitHub Security tab.
    - Updated the 'checkout' action to fetch the full history by setting 'fetch-depth' to 0.

<!-- Generated by sourcery-ai[bot]: end summary -->