### PR TITLE
ci: Fix trivy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           scan-type: 'fs'
           format: 'sarif'
           output: 'trivy.sarif'
-      - name: Upload Trivy scan results to GitHub Security tab
+      - name: Upload SARIF results
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy.sarif'


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the CI configuration for the Trivy job by adding required permissions and renaming the step for uploading SARIF results.

- **CI**:
    - Added necessary permissions for the Trivy job to write contents and security events.
    - Renamed the step for uploading SARIF results to be more generic.

<!-- Generated by sourcery-ai[bot]: end summary -->