### PR TITLE
ci: Fix trivy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,9 @@ jobs:
       - uses: actions/checkout@v4.2.1
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.28.0
+        continue-on-error: true
         with:
-          scan-type: "repo"
+          scan-type: "fs"
           scan-ref: "."
           output: "trivy.txt"
           hide-progress: true


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Modify the Trivy scan type from 'repo' to 'fs' in the CI workflow to ensure correct scanning of the file system.