### PR TITLE
feat: Add port of itertools.batched

### DIFF
--- a/src/glue_utils/helpers.py
+++ b/src/glue_utils/helpers.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any
+from itertools import islice
+from typing import TYPE_CHECKING, Any, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 def generate_partitioned_path(**kwargs: Any) -> str:  # noqa: ANN401
@@ -27,3 +31,38 @@ def generate_partitioned_path(**kwargs: Any) -> str:  # noqa: ANN401
 
     """
     return "/".join(f"{key}={value}" for key, value in kwargs.items())
+
+
+T = TypeVar("T")
+
+
+def batched(iterable: Iterable[T], n: int) -> Iterable[tuple[T, ...]]:
+    """Yield successive n-sized chunks from an iterable.
+
+    Note: This is a simple port of itertools.batched() from Python 3.12.
+    https://docs.python.org/3/library/itertools.html#itertools.batched
+
+    Parameters
+    ----------
+    iterable : Iterable[T]
+        The iterable to be batched.
+    n : int
+        The number of items per batch. Must be at least 1.
+
+    Yields
+    ------
+    Iterable[tuple[T, ...]]
+        An iterable of tuples, each containing up to n items from the input iterable.
+
+    Raises
+    ------
+    ValueError
+        If n is less than 1.
+
+    """
+    if n < 1:
+        msg = "n must be at least one"
+        raise ValueError(msg)
+    iterator = iter(iterable)
+    while batch := tuple(islice(iterator, n)):
+        yield batch

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
-from glue_utils.helpers import generate_partitioned_path
+from glue_utils.helpers import batched, generate_partitioned_path
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 @pytest.mark.parametrize(
@@ -27,3 +32,46 @@ def test_generate_partitioned_path(
     expected_path,
 ) -> None:
     assert generate_partitioned_path(**partitions) == expected_path
+
+
+class TestBatched:
+    @pytest.mark.parametrize(
+        ("iterable", "n", "expected"),
+        [
+            (
+                [1, 2, 3, 4, 5, 6, 7, 8, 9],
+                3,
+                [(1, 2, 3), (4, 5, 6), (7, 8, 9)],
+            ),
+            (
+                [],
+                3,
+                [],
+            ),
+            (
+                [1, 2, 3],
+                5,
+                [(1, 2, 3)],
+            ),
+            (
+                [1, 2, 3],
+                1,
+                [(1,), (2,), (3,)],
+            ),
+        ],
+    )
+    def test_batched(self, iterable, n, expected):
+        assert list(batched(iterable, n)) == expected
+
+    def test_batched_with_generator(self):
+        def gen() -> Generator[int, None, None]:
+            yield from range(5)
+
+        iterable = gen()
+        n = 2
+        expected = [(0, 1), (2, 3), (4,)]
+        assert list(batched(iterable, n)) == expected
+
+    def test_batched_with_invalid_n(self):
+        with pytest.raises(ValueError):  # noqa: PT011
+            list(batched([1, 2, 3], 0))


### PR DESCRIPTION
## Summary by Sourcery

Add a new 'batched' function to the helpers module, which provides functionality to yield n-sized chunks from an iterable, similar to itertools.batched in Python 3.12. Include comprehensive tests to ensure correct behavior for different input types and sizes.

New Features:
- Introduce the 'batched' function, a port of itertools.batched from Python 3.12, which yields successive n-sized chunks from an iterable.

Tests:
- Add tests for the new 'batched' function, including parameterized tests for various input scenarios and a specific test for generator input.