### PR TITLE
ci: Fix trivy error on too many requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,12 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.28.0
         continue-on-error: true
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
         with:
-          scan-type: "fs"
+          scan-type: "repo"
           scan-ref: "."
           output: "trivy.txt"
-          hide-progress: true
       - name: Publish Trivy output to Summary
         run: |
           if [[ -s trivy.txt ]]; then


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Set the TRIVY_DB_REPOSITORY environment variable to use a specific database repository for Trivy.