### PR TITLE
ci: Do not persist git credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         python-version: ["3.9", "3.10"]
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5.3.0
         with:
@@ -62,6 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Diffset
         id: diffset
@@ -95,6 +98,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.29.0
         continue-on-error: true
@@ -123,6 +128,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
       - name: Validate Dockerfile using hadolint
         uses: hadolint/hadolint-action@v3.1.0
         with:
@@ -133,6 +140,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
       - name: Check Makefile for errors
         uses: Uno-Takashi/checkmake-action@main
 
@@ -145,6 +154,8 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
       - name: Check code using Checkov
         uses: bridgecrewio/checkov-action@master
         with:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Disable the persistence of git credentials in all CI workflow steps using the actions/checkout action.