### PR TITLE
Support conversion for primitive field types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ python_files = ["test_*.py"]
 filterwarnings = [
     "ignore::FutureWarning:pyspark.sql.context",
     "ignore::UserWarning:test.test_options",
+    "ignore::UserWarning:test.pyspark.test_options",
 ]
 junit_suite_name = "glue_utils"
 

--- a/src/glue_utils/options.py
+++ b/src/glue_utils/options.py
@@ -1,4 +1,7 @@
-"""Module for conveniently parsing options resolved from command-line arguments."""
+"""Module for conveniently parsing options resolved from command-line arguments.
+
+This is limited to python 3.9 since Glue PythonShell jobs only supports 3.9.
+"""
 
 from __future__ import annotations
 
@@ -17,7 +20,7 @@ class UnsupportedTypeWarning(UserWarning):
 
 @dataclass
 class BaseOptions:
-    """Dataclass for storing resolved options."""
+    """Dataclass for storing resolved options for Glue Pythonshell jobs."""
 
     @classmethod
     def __init_subclass__(cls) -> None:

--- a/src/glue_utils/pyspark/__init__.py
+++ b/src/glue_utils/pyspark/__init__.py
@@ -2,8 +2,10 @@ from .connection_types import ConnectionType
 from .context import GlueContextOptions, GluePySparkContext
 from .formats import Format
 from .job import GluePySparkJob
+from .options import BaseOptions
 
 __all__ = [
+    "BaseOptions",
     "ConnectionType",
     "Format",
     "GlueContextOptions",

--- a/src/glue_utils/pyspark/options.py
+++ b/src/glue_utils/pyspark/options.py
@@ -1,0 +1,127 @@
+"""Module for conveniently parsing options resolved from command-line arguments."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, fields
+from typing import Any, ClassVar, get_args, get_origin, get_type_hints
+
+from awsglue.utils import getResolvedOptions
+from typing_extensions import Self
+
+
+class UnsupportedTypeError(TypeError):
+    """Error raised when field type is not supported for conversion."""
+
+    def __init__(self, target_type: type) -> None:
+        """Initialize with unsupported type."""
+        msg = f"Unsupported type annotation: {target_type}"
+        super().__init__(msg)
+
+
+@dataclass
+class BaseOptions:
+    """Dataclass for storing resolved options with type conversion support."""
+
+    # Class variables for boolean conversion - can be overridden in subclasses
+    TRUE_VALUES: ClassVar[set[str]] = {"1", "true", "yes", "y", "t"}
+    FALSE_VALUES: ClassVar[set[str]] = {"0", "false", "no", "n", "f"}
+
+    def __post_init__(self) -> None:
+        """Convert string values to their annotated types after initialization."""
+        type_hints = get_type_hints(self.__class__)
+        for field in fields(self):
+            value = getattr(self, field.name)
+            target_type = type_hints.get(field.name, str)
+            real_type = self._resolve_real_type(target_type, value)
+            if value is not None and not isinstance(value, real_type):
+                try:
+                    converted = self.convert_value(value, real_type)
+                    setattr(self, field.name, converted)
+                except Exception as e:
+                    msg = f"Failed to convert field '{field.name}' value '{value}' to {real_type}: {e}"
+                    raise ValueError(msg) from e
+
+    def convert_value(self, value: object, target_type: type) -> object:
+        """Convert value to the target_type, supporting str, int, float, bool."""
+        if target_type is str:
+            return str(value)
+        if target_type is int:
+            return int(str(value))
+        if target_type is float:
+            return float(str(value))
+        if target_type is bool:
+            return self.convert_to_bool(value)
+        raise UnsupportedTypeError(target_type)
+
+    def convert_to_bool(self, value: object) -> bool:
+        """Convert value to bool with special string handling."""
+        if isinstance(value, bool):
+            return value
+        val = str(value).strip().lower()
+        if val in self.TRUE_VALUES:
+            return True
+        if val in self.FALSE_VALUES:
+            return False
+        msg = f"Cannot convert '{value}' to bool."
+        raise ValueError(msg)
+
+    @classmethod
+    def from_sys_argv(cls) -> Self:
+        """Create an instance of the class from Glue's resolved arguments."""
+        resolved_options = getResolvedOptions(
+            sys.argv, [field.name for field in fields(cls)]
+        )
+
+        return cls.from_options(resolved_options)
+
+    @classmethod
+    def from_options(cls, options: dict[str, Any] | None = None) -> Self:
+        """Create an instance of the class from the provided options."""
+        if not options:
+            return cls()
+
+        field_names = {field.name for field in fields(cls)}
+
+        return cls(
+            **{key: value for key, value in options.items() if key in field_names},
+        )
+
+    @staticmethod
+    def _resolve_real_type(target_type: type, value: object) -> type:
+        """Resolve the real type for Optional/Union annotations."""
+        origin = get_origin(target_type)
+        args = get_args(target_type)
+
+        if origin is None or not args:
+            return target_type
+
+        return BaseOptions._resolve_union_type(args, value)
+
+    @staticmethod
+    def _resolve_union_type(args: tuple[Any, ...], value: object) -> type:
+        """Resolve the actual type from Union/Optional type arguments."""
+        non_none_types = BaseOptions._extract_non_none_types(args)
+
+        if BaseOptions._should_use_value_type(non_none_types, value):
+            return type(value) if value is not None else str
+
+        return BaseOptions._get_first_valid_type(non_none_types)
+
+    @staticmethod
+    def _extract_non_none_types(args: tuple[Any, ...]) -> tuple[Any, ...]:
+        """Extract non-None types from Union/Optional arguments."""
+        return tuple(t for t in args if t is not type(None))
+
+    @staticmethod
+    def _should_use_value_type(non_none_types: tuple[Any, ...], value: object) -> bool:
+        """Check if we should use the value's type instead of annotation."""
+        return not non_none_types or value is None
+
+    @staticmethod
+    def _get_first_valid_type(non_none_types: tuple[Any, ...]) -> type:
+        """Get the first valid type from non-None types, defaulting to str."""
+        if not non_none_types:
+            return str
+        real_type = non_none_types[0]
+        return real_type if isinstance(real_type, type) else str

--- a/test/pyspark/test_options.py
+++ b/test/pyspark/test_options.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import ClassVar, Optional
+from unittest.mock import patch
+
+import pytest
+
+from glue_utils.pyspark import BaseOptions
+
+
+@pytest.fixture
+def mock_get_resolved_options():
+    with patch("glue_utils.pyspark.options.getResolvedOptions") as patched:
+        yield patched
+
+
+class TestBaseOptions:
+    @pytest.mark.parametrize(
+        ("args", "resolved_options"),
+        [
+            (
+                ["--JOB_NAME", "test-job"],
+                {"JOB_NAME": "test-job"},
+            ),
+            ([], {}),
+        ],
+    )
+    def test_from_sys_argv(
+        self,
+        args,
+        resolved_options,
+        mock_get_resolved_options,
+    ) -> None:
+        with patch("sys.argv", ["test.py", *args]):
+            mock_get_resolved_options.return_value = resolved_options
+            options = BaseOptions.from_sys_argv()
+
+            assert len(fields(options)) == 0
+
+
+@dataclass
+class Options(BaseOptions):
+    connection_name: str
+    source_database: str
+
+
+class TestOptions:
+    def test_from_sys_argv(self, mock_get_resolved_options) -> None:
+        mock_get_resolved_options.return_value = {
+            "JOB_NAME": "test-job",
+            "connection_name": "test-connection",
+            "source_database": "test-source-database",
+        }
+
+        options = Options.from_sys_argv()
+
+        assert options.connection_name == "test-connection"
+        assert options.source_database == "test-source-database"
+        assert len(fields(options)) == 2
+
+    def test_missing_options(self, mock_get_resolved_options) -> None:
+        mock_get_resolved_options.return_value = {
+            "connection_name": "test-connection",
+        }
+
+        with pytest.raises(TypeError):
+            Options.from_sys_argv()
+
+
+@dataclass
+class NullableOptions(BaseOptions):
+    connection_name: str
+    source_database: Optional[str] = None
+
+
+class TestNullableOptions:
+    def test_from_sys_argv(self, mock_get_resolved_options) -> None:
+        mock_get_resolved_options.return_value = {
+            "JOB_NAME": "test-job",
+            "connection_name": "test-connection",
+            "source_database": "test-source-database",
+        }
+
+        options = NullableOptions.from_sys_argv()
+
+        assert options.connection_name == "test-connection"
+        assert options.source_database == "test-source-database"
+        assert len(fields(options)) == 2
+
+    def test_missing_options(self, mock_get_resolved_options) -> None:
+        mock_get_resolved_options.return_value = {
+            "connection_name": "test-connection",
+        }
+
+        options = NullableOptions.from_sys_argv()
+
+        assert options.connection_name == "test-connection"
+        assert options.source_database is None
+        assert len(fields(options)) == 2
+
+
+@dataclass
+class NullableOptionsWithDefaults(BaseOptions):
+    connection_name: str = "my connection"
+    source_database: Optional[str] = "my source"
+
+
+class TestNullableOptionsWithDefaults:
+    def test_from_sys_argv(self, mock_get_resolved_options) -> None:
+        mock_get_resolved_options.return_value = {
+            "JOB_NAME": "test-job",
+            "connection_name": "test-connection",
+            "source_database": "test-source-database",
+        }
+
+        options = NullableOptionsWithDefaults.from_sys_argv()
+
+        assert options.connection_name == "test-connection"
+        assert options.source_database == "test-source-database"
+        assert len(fields(options)) == 2
+
+    def test_missing_options(self, mock_get_resolved_options) -> None:
+        mock_get_resolved_options.return_value = {
+            "JOB_NAME": "test-job",
+        }
+
+        options = NullableOptionsWithDefaults.from_sys_argv()
+
+        assert options.connection_name == "my connection"
+        assert options.source_database == "my source"
+        assert len(fields(options)) == 2
+
+
+@dataclass
+class PrimitiveOptions(BaseOptions):
+    port: int
+    price: float
+    enabled: bool
+    name: str
+
+
+class TestPrimitiveOptions:
+    def test_from_sys_argv_converts_types(self, mock_get_resolved_options) -> None:
+        mock_get_resolved_options.return_value = {
+            "port": "5432",
+            "price": "12.34",
+            "enabled": "true",
+            "name": "my-job",
+        }
+        options = PrimitiveOptions.from_sys_argv()
+        assert isinstance(options.port, int)
+        assert options.port == 5432
+        assert isinstance(options.price, float)
+        assert options.price == 12.34
+        assert isinstance(options.enabled, bool)
+        assert options.enabled is True
+        assert isinstance(options.name, str)
+        assert options.name == "my-job"
+
+    @pytest.mark.parametrize(
+        ("enabled_str", "expected"),
+        [
+            ("true", True),
+            ("True", True),
+            ("1", True),
+            ("yes", True),
+            ("y", True),
+            ("t", True),
+            ("false", False),
+            ("False", False),
+            ("0", False),
+            ("no", False),
+            ("n", False),
+            ("f", False),
+        ],
+    )
+    def test_bool_conversion_variants(
+        self, mock_get_resolved_options, enabled_str, expected
+    ) -> None:
+        mock_get_resolved_options.return_value = {
+            "port": "1234",
+            "price": "1.0",
+            "enabled": enabled_str,
+            "name": "test",
+        }
+        options = PrimitiveOptions.from_sys_argv()
+        assert options.enabled is expected
+
+    def test_invalid_int_raises(self, mock_get_resolved_options) -> None:
+        mock_get_resolved_options.return_value = {
+            "port": "not-an-int",
+            "price": "1.0",
+            "enabled": "true",
+            "name": "test",
+        }
+        with pytest.raises(
+            ValueError,
+            match="Failed to convert field 'port' value 'not-an-int' to <class 'int'>",
+        ):
+            PrimitiveOptions.from_sys_argv()
+
+    def test_invalid_float_raises(self, mock_get_resolved_options) -> None:
+        mock_get_resolved_options.return_value = {
+            "port": "1234",
+            "price": "not-a-float",
+            "enabled": "true",
+            "name": "test",
+        }
+        with pytest.raises(
+            ValueError,
+            match="Failed to convert field 'price' value 'not-a-float' to <class 'float'>",
+        ):
+            PrimitiveOptions.from_sys_argv()
+
+    def test_invalid_bool_raises(self, mock_get_resolved_options) -> None:
+        mock_get_resolved_options.return_value = {
+            "port": "1234",
+            "price": "1.0",
+            "enabled": "not-a-bool",
+            "name": "test",
+        }
+        with pytest.raises(
+            ValueError,
+            match="Failed to convert field 'enabled' value 'not-a-bool' to <class 'bool'>",
+        ):
+            PrimitiveOptions.from_sys_argv()
+
+    def test_from_options_converts_types(self, mock_get_resolved_options) -> None:
+        options = PrimitiveOptions.from_options(
+            {
+                "port": "8080",
+                "price": "99.99",
+                "enabled": "false",
+                "name": "test-job",
+            }
+        )
+        assert isinstance(options.port, int)
+        assert options.port == 8080
+        assert isinstance(options.price, float)
+        assert options.price == 99.99
+        assert isinstance(options.enabled, bool)
+        assert options.enabled is False
+        assert isinstance(options.name, str)
+        assert options.name == "test-job"
+
+
+@dataclass
+class MixedOptionsWithDefaults(BaseOptions):
+    host: str = "localhost"
+    port: int = 5432
+    timeout: float = 30.0
+    debug: bool = False
+
+
+class TestMixedOptionsWithDefaults:
+    def test_with_all_values(self, mock_get_resolved_options) -> None:
+        mock_get_resolved_options.return_value = {
+            "host": "production.db",
+            "port": "3306",
+            "timeout": "60.5",
+            "debug": "true",
+        }
+        options = MixedOptionsWithDefaults.from_sys_argv()
+        assert options.host == "production.db"
+        assert options.port == 3306
+        assert options.timeout == 60.5
+        assert options.debug is True
+
+    def test_with_partial_values(self, mock_get_resolved_options) -> None:
+        mock_get_resolved_options.return_value = {
+            "port": "1234",
+            "debug": "true",
+        }
+        options = MixedOptionsWithDefaults.from_sys_argv()
+        assert options.host == "localhost"  # default value
+        assert options.port == 1234  # converted from string
+        assert options.timeout == 30.0  # default value
+        assert options.debug is True  # converted from string
+
+    def test_with_no_values(self, mock_get_resolved_options) -> None:
+        mock_get_resolved_options.return_value = {}
+        options = MixedOptionsWithDefaults.from_sys_argv()
+        assert options.host == "localhost"
+        assert options.port == 5432
+        assert options.timeout == 30.0
+        assert options.debug is False
+
+
+@dataclass
+class OptionalPrimitiveOptions(BaseOptions):
+    connection_name: str
+    port: Optional[int] = None
+    debug: Optional[bool] = None
+
+
+class TestOptionalPrimitiveOptions:
+    def test_with_optional_values(self, mock_get_resolved_options) -> None:
+        mock_get_resolved_options.return_value = {
+            "connection_name": "test-conn",
+            "port": "5432",
+            "debug": "true",
+        }
+        options = OptionalPrimitiveOptions.from_sys_argv()
+        assert options.connection_name == "test-conn"
+        assert isinstance(options.port, int)
+        assert options.port == 5432
+        assert isinstance(options.debug, bool)
+        assert options.debug is True
+
+    def test_with_missing_optional_values(self, mock_get_resolved_options) -> None:
+        mock_get_resolved_options.return_value = {
+            "connection_name": "test-conn",
+        }
+        options = OptionalPrimitiveOptions.from_sys_argv()
+        assert options.connection_name == "test-conn"
+        assert options.port is None
+        assert options.debug is None
+
+
+class TestCustomBooleanValues:
+    """Test custom boolean conversion values."""
+
+    def test_default_boolean_values(self) -> None:
+        """Test that default TRUE_VALUES and FALSE_VALUES work correctly."""
+        options = BaseOptions()
+
+        # Test default TRUE_VALUES
+        for true_val in BaseOptions.TRUE_VALUES:
+            assert options.convert_to_bool(true_val) is True
+            assert options.convert_to_bool(true_val.upper()) is True
+            assert options.convert_to_bool(f" {true_val} ") is True  # with whitespace
+
+        # Test default FALSE_VALUES
+        for false_val in BaseOptions.FALSE_VALUES:
+            assert options.convert_to_bool(false_val) is False
+            assert options.convert_to_bool(false_val.upper()) is False
+            assert options.convert_to_bool(f" {false_val} ") is False  # with whitespace
+
+    def test_convert_to_bool_invalid_value(self) -> None:
+        """Test convert_to_bool with invalid string values."""
+        options = BaseOptions()
+        with pytest.raises(ValueError, match="Cannot convert 'invalid' to bool"):
+            options.convert_to_bool("invalid")
+
+        with pytest.raises(ValueError, match="Cannot convert 'maybe' to bool"):
+            options.convert_to_bool("maybe")
+
+
+@dataclass
+class CustomBooleanOptions(BaseOptions):
+    """Custom options class with overridden boolean values."""
+
+    # Override boolean conversion values
+    TRUE_VALUES: ClassVar[set[str]] = {"ja", "oui", "si", "1"}
+    FALSE_VALUES: ClassVar[set[str]] = {"nein", "non", "no", "0"}
+
+    enabled: bool
+
+
+@dataclass
+class ExtendedBooleanOptions(BaseOptions):
+    """Options class that extends boolean values instead of replacing them."""
+
+    # Extend the boolean values by combining with parent values
+    TRUE_VALUES: ClassVar[set[str]] = BaseOptions.TRUE_VALUES | {"on", "enabled"}
+    FALSE_VALUES: ClassVar[set[str]] = BaseOptions.FALSE_VALUES | {"off", "disabled"}
+
+    active: bool


### PR DESCRIPTION
This PR enhances BaseOptions to automatically convert string command-line arguments to their annotated primitive types (int, float, bool, str).

**Key Changes:**
- BaseOptions now converts string values from sys.argv to annotated types automatically
- Supports int, float, bool, and str conversions
- Handles Optional types and Union types properly  
- Boolean conversion supports "true", "1", "yes", "y", "t" for True and "false", "0", "no", "n", "f" for False
- Added comprehensive error handling with clear messages

**Example:**
```python
@dataclass  
class Options(BaseOptions):
    connection_name: str
    source_database: str
    port: int           # "5432" → 5432
    truncate: bool      # "true" → True
    timeout: float      # "30.5" → 30.5
```

**Benefits:**
- No manual type conversion needed
- Maintains type safety
- Backward compatible
- Clear error messages for invalid conversions

This PR closes #64 and #125.

## Summary by Sourcery

Add automatic conversion of command-line argument strings to annotated primitive types in BaseOptions for Glue PySpark jobs, with support for Optional and Union annotations, boolean variants, and clear error messages; expose BaseOptions in the pyspark module; update test configuration and add comprehensive tests.

New Features:
- Automatically convert resolved CLI arguments to annotated primitive types (int, float, bool, str)

Enhancements:
- Handle Optional and Union type annotations when resolving field types
- Support multiple string variants for boolean conversion
- Provide descriptive error messages for failed conversions
- Expose BaseOptions in the glue_utils.pyspark package

Build:
- Add warning filter for pyspark options tests in pyproject.toml

Documentation:
- Update BaseOptions docstring to reference Glue PySpark job context

Tests:
- Add extensive tests covering type conversion, optional and default values, boolean variants, and error scenarios for BaseOptions