### PR TITLE
fix: Include py.typed in package

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -148,7 +148,7 @@ typing-extensions==4.14.0 \
     --hash=sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4 \
     --hash=sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af
     # via exceptiongroup
-zipp==3.22.0 \
-    --hash=sha256:dd2f28c3ce4bc67507bfd3781d21b7bb2be31103b51a4553ad7d90b84e57ace5 \
-    --hash=sha256:fe208f65f2aca48b81f9e6fd8cf7b8b32c26375266b009b413d45306b6148343
+zipp==3.23.0 \
+    --hash=sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e \
+    --hash=sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166
     # via importlib-metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
-include = ["src/**/*.py", "tests", "README.md", "pyproject.toml", "LICENSE"]
+include = ["src", "test", "README.md", "pyproject.toml", "LICENSE", "py.typed"]
 
 [dependency-groups]
 dev = ["bumpver>=2024.1130", "mypy>=1.16.0", "ruff>=0.11.13"]


### PR DESCRIPTION
## Summary by Sourcery

Include the py.typed marker in the sdist include list and update the zipp dependency version in Docker requirements.

Bug Fixes:
- Include py.typed in source distribution to enable PEP 561 typing support.

Chores:
- Bump zipp to 3.23.0 in Docker requirements with updated hashes.