### PR TITLE
feat: Support list and dict options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ ignore = [
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.lint.mccabe]
-max-complexity = 5
+max-complexity = 8
 
 [tool.ruff.lint.per-file-ignores]
 "test/**" = [


### PR DESCRIPTION
## Summary by Sourcery

Support list and dict option types by introducing dedicated conversion methods, updating the conversion dispatch and tests to validate the new behavior, and adjust lint complexity constraints.

New Features:
- Add default support for converting option values to list and dict types, handling JSON strings and comma-separated values

Enhancements:
- Increase ruff's max McCabe complexity threshold from 5 to 8 for additional conversion logic

Tests:
- Update tests to use json_list and json_obj fields with built-in list and dict conversion and remove legacy custom converters